### PR TITLE
master's thesis fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,9 @@ It adds parallel execution to the original [Isabelle LLVM](http://www21.in.tum.d
 
 For build instructions and starting points to browse the theories, see [html/index.html].
 
+# Regression Test
 
+The regression test can be run using `make` in the [regression](regression) directory. The following commands must be available.
+- [Valgrind](https://valgrind.org/) as `valgrind` 
+- clang as `clang`
+- Intel's [intruction set emulator](https://www.intel.com/content/www/us/en/developer/articles/tool/software-development-emulator.html) as `sed`

--- a/regression/Makefile
+++ b/regression/Makefile
@@ -1,4 +1,4 @@
-ISABELLE=~/opt/Isabelle2021-1/bin/isabelle build -b
+ISABELLE=isabelle build -b
 
 all: tests
 

--- a/thys/basic/kernel/LLVM_Codegen.thy
+++ b/thys/basic/kernel/LLVM_Codegen.thy
@@ -2113,6 +2113,8 @@ begin
           line [word "#ifndef", hfsym],
           line [word "#define", hfsym, word "1"],
           fbrk, fbrk,
+          line [word "#include <stdint.h>"],
+          fbrk, fbrk,         
           tydefs_proto_to_Cs tydefs,
           fbrk, fbrk,
           tydefs_to_Cs tydefs,

--- a/thys/examples/LLVM_Examples.thy
+++ b/thys/examples/LLVM_Examples.thy
@@ -40,11 +40,11 @@ lemma exp_aux1:
   assumes "2 ^ nat k < (N::int)" "t \<le> k" "0 < t" 
   shows "2 * 2 ^ nat (k - t) < N"
 proof -
-  have "\<lbrakk>2 ^ k < N; 0 < t; t \<le> k\<rbrakk> \<Longrightarrow> 2 * 2 ^ (k - t) < (N::int)" for k t :: nat
-    by (metis Suc_leI diff_less less_le_trans not_less power.simps(2) power_increasing_iff rel_simps(49) semiring_norm(76))
-  with assms show ?thesis
-    by (auto simp add: nat_diff_distrib' dest!: nat_mono simp flip: zero_less_nat_eq)
-qed  
+  from assms have "nat (k - t) + 1 \<le> nat k" by auto
+  with assms have "(2::int) ^ (nat (k - t) + 1) \<le> 2 ^ nat k"
+    using one_le_numeral power_increasing by blast
+  thus ?thesis using assms by simp
+qed
   
 lemma exp_aux2:  "\<lbrakk>t \<le> k; 0 < t\<rbrakk> \<Longrightarrow> nat (1+k-t) = Suc (nat (k-t))" by simp
 

--- a/thys/lib/Frame_Infer.thy
+++ b/thys/lib/Frame_Infer.thy
@@ -369,6 +369,9 @@ lemma
   by (auto simp: vcg_tag_defs)
 
 
+lemma EXTRACT_True [simp, intro!]: "EXTRACT True" unfolding EXTRACT_def by simp
+
+
 ML \<open>
   structure Fri_Extract = struct
     (* TODO: Move *)

--- a/thys/sepref/Sepref_HOL_Bindings.thy
+++ b/thys/sepref/Sepref_HOL_Bindings.thy
@@ -1207,11 +1207,11 @@ proof -
           POSTCOND_def STATE_extract(2) shiftr_div_2n 
        uint_shiftl exists_pure_conv)
    show \<open>wpa ( asf) (ll_shl ai bi)
-         (\<lambda>r. POSTCOND asf
+         (\<lambda>r s. EXTRACT (POSTCOND asf
                ((\<up>((ai, a) \<in> snat_rel) \<and>*
                  \<up>((bi, b) \<in> snat_rel) \<and>*
                  \<up>True \<and>*
-                 (\<lambda>s. \<exists>x. (\<up>((r, x) \<in> snat_rel) \<and>* \<up>(x = a << b)) s))))
+                 (\<lambda>s. \<exists>x. (\<up>((r, x) \<in> snat_rel) \<and>* \<up>(x = a << b)) s))) s))
          s\<close>
      using le a b state
      unfolding snat_rel_def snat.rel_def br_def
@@ -1220,7 +1220,7 @@ proof -
         nat_div_distrib nat_power_eq pred_lift_merge_simps sint_eq_uint max_snat_def
         cnv_snat_to_uint(1) in_br_conv snat.rel_def snat_invar_def
       simp flip: word_to_lint_shl nat_uint_eq)
-     apply (simp_all add: POSTCOND_def STATE_extract shiftr_div_2n 
+     apply (simp_all add: POSTCOND_def STATE_extract EXTRACT_def shiftr_div_2n 
        uint_shiftl exists_pure_conv )
     
      apply (subgoal_tac "nat (take_bit (size ai) (uint ai << unat bi)) = unat ai << unat bi")

--- a/thys/vcg/LLVM_Shallow_RS.thy
+++ b/thys/vcg/LLVM_Shallow_RS.thy
@@ -478,11 +478,6 @@ lemma ll_malloc_rule[vcg_rules]:
   unfolding ll_malloc_def ll_pto_def ll_malloc_tag_def llvm_alloc_def    
   supply [simp] = unat_gt_0 abase_ptr_iff the_raw_PTR_aidx blockvp_range_conv ll_range_init_conv_aux
   apply vcg  
-  apply vcg_normalize
-  subgoal for r (* TODO: Missing pure extraction on fri *)
-    apply (cases "llvm_ptr_is_block_base r"; simp add: sep_algebra_simps)
-    apply vcg
-    done
   done
   
 (* TODO: Move *)  

--- a/thys/vcg/Sep_Generic_Wp.thy
+++ b/thys/vcg/Sep_Generic_Wp.thy
@@ -994,7 +994,7 @@ lemma DECOMP_HTRIPLEI: "\<phi> \<Longrightarrow> DECOMP_HTRIPLE \<phi>" unfoldin
     using assms unfolding vcg_tag_defs .
   
   lemma htriple_vcgI[htriple_vcg_intros]: 
-    assumes "\<And>asf s. STATE asf P s \<Longrightarrow> EXTRACT (wpa asf c (\<lambda>r. POSTCOND asf (Q r)) s)"
+    assumes "\<And>asf s. STATE asf P s \<Longrightarrow> EXTRACT (wpa asf c (\<lambda>r s. EXTRACT (POSTCOND asf (Q r) s)) s)"
     shows "htriple P c Q"
     apply (rule htripleI)
     using assms unfolding vcg_tag_defs STATE_def .


### PR DESCRIPTION
Add fixes from the pair programming session, notably adding the missing EXTRACT to the vcg.
The regression test succeeds as far as I can tell:

```
isabelle build -b -D ../thys
Presentation in "/home/leander/.isabelle/Isabelle2021-1/browser_info"
Presenting Isabelle_LLVM ...
0:00:22 elapsed time
make -C src
make[1]: Entering directory '/home/leander/Isabelle/isabelle_llvm/regression/src'
../bin/open_list
../bin/bin_search
valgrind -q --leak-check=full --error-exitcode=2 ../bin/open_list
valgrind -q --leak-check=full --error-exitcode=2 ../bin/bin_search
../bin/kmp
clang++ -std=c++20 -stdlib=libstdc++ -Wall -flto -O3 -I "../gencode" -lpthread ../../src/lib_isabelle_llvm.cpp ../../src/lib_isabelle_llvm_par.cpp sorting.cpp ../gencode/sorting.ll -o ../bin/sorting
valgrind -q --leak-check=full --error-exitcode=2 ../bin/kmp
clang -O3 -I "../gencode" -Wall -lpthread ../../src/lib_isabelle_llvm.c -lm -ffp-contract=off test_double.c ../gencode/test_double.ll -o ../bin/test_double
clang -O3 -I "../gencode" -Wall -lpthread ../../src/lib_isabelle_llvm.c -lm -march=x86-64 -mavx512f -ffp-contract=off test_avx512f.c ../gencode/test_avx512f.ll -o ../bin/test_avx512f
../bin/test_double
sde -- ../bin/test_avx512f
valgrind -q --leak-check=full --error-exitcode=2 ../bin/test_double
../bin/sorting
  introsort-uint64.time: 57
  pdqsort-uint64.time: 57
  parqsort-uint64.time: 18
  introsort-llstring.time: 138
  pdqsort-llstring.time: 100
  parqsort-llstring.time: 30
valgrind -q --leak-check=full --error-exitcode=2 ../bin/sorting
  introsort-uint64.time: 195
  pdqsort-uint64.time: 202
  parqsort-uint64.time: 488
  introsort-llstring.time: 1107
  pdqsort-llstring.time: 1033
  parqsort-llstring.time: 1069
make[1]: Leaving directory '/home/leander/Isabelle/isabelle_llvm/regression/src'
```